### PR TITLE
Implemented basic "Check-In" functionality, which simply logs when a user has checked into an existing Building

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "require": {
-    "php": "^7.0",
+    "php": "^7.1",
     "ext-pdo": "*",
     "ext-pdo_sqlite": "*",
     "bernard/bernard": "^1.0@DEV",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d27ad5e556afaf6ed1fad63ded0202b6",
+    "content-hash": "4d3e1059c5c0110b56d73d79c8292ffe",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -63,7 +63,7 @@
                 "assertion",
                 "validation"
             ],
-            "time": "2016-07-28 19:35:30"
+            "time": "2016-07-28T19:35:30+00:00"
         },
         {
             "name": "bernard/bernard",
@@ -131,7 +131,7 @@
                 "message queue",
                 "queue"
             ],
-            "time": "2016-09-09 12:28:21"
+            "time": "2016-09-09T12:28:21+00:00"
         },
         {
             "name": "bernard/normalt",
@@ -174,7 +174,7 @@
                 "denormalization",
                 "normalization"
             ],
-            "time": "2016-05-03 08:09:59"
+            "time": "2016-05-03T08:09:59+00:00"
         },
         {
             "name": "container-interop/container-interop",
@@ -201,7 +201,7 @@
                 "MIT"
             ],
             "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
-            "time": "2014-12-30 15:22:37"
+            "time": "2014-12-30T15:22:37+00:00"
         },
         {
             "name": "doctrine/annotations",
@@ -269,7 +269,7 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2015-08-31 12:32:49"
+            "time": "2015-08-31T12:32:49+00:00"
         },
         {
             "name": "doctrine/cache",
@@ -339,7 +339,7 @@
                 "cache",
                 "caching"
             ],
-            "time": "2015-12-31 16:37:02"
+            "time": "2015-12-31T16:37:02+00:00"
         },
         {
             "name": "doctrine/collections",
@@ -405,7 +405,7 @@
                 "collections",
                 "iterator"
             ],
-            "time": "2015-04-14 22:21:58"
+            "time": "2015-04-14T22:21:58+00:00"
         },
         {
             "name": "doctrine/common",
@@ -478,7 +478,7 @@
                 "persistence",
                 "spl"
             ],
-            "time": "2015-12-25 13:18:31"
+            "time": "2015-12-25T13:18:31+00:00"
         },
         {
             "name": "doctrine/dbal",
@@ -549,7 +549,7 @@
                 "persistence",
                 "queryobject"
             ],
-            "time": "2016-09-09 19:13:33"
+            "time": "2016-09-09T19:13:33+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -616,7 +616,7 @@
                 "singularize",
                 "string"
             ],
-            "time": "2015-11-06 14:35:42"
+            "time": "2015-11-06T14:35:42+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -670,7 +670,7 @@
                 "lexer",
                 "parser"
             ],
-            "time": "2014-09-09 13:34:57"
+            "time": "2014-09-09T13:34:57+00:00"
         },
         {
             "name": "filp/whoops",
@@ -730,7 +730,7 @@
                 "whoops",
                 "zf2"
             ],
-            "time": "2016-05-06 18:25:35"
+            "time": "2016-05-06T18:25:35+00:00"
         },
         {
             "name": "nikic/fast-route",
@@ -773,7 +773,7 @@
                 "router",
                 "routing"
             ],
-            "time": "2016-06-12 19:08:51"
+            "time": "2016-06-12T19:08:51+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -821,7 +821,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2016-04-03 06:00:07"
+            "time": "2016-04-03T06:00:07+00:00"
         },
         {
             "name": "prooph/common",
@@ -874,7 +874,7 @@
                 "common",
                 "prooph"
             ],
-            "time": "2016-05-14 06:40:38"
+            "time": "2016-05-14T06:40:38+00:00"
         },
         {
             "name": "prooph/event-sourcing",
@@ -933,7 +933,7 @@
                 "ddd",
                 "prooph"
             ],
-            "time": "2015-11-22 22:43:03"
+            "time": "2015-11-22T22:43:03+00:00"
         },
         {
             "name": "prooph/event-store",
@@ -1009,7 +1009,7 @@
                 "ddd",
                 "prooph"
             ],
-            "time": "2016-09-05 09:15:14"
+            "time": "2016-09-05T09:15:14+00:00"
         },
         {
             "name": "prooph/event-store-bus-bridge",
@@ -1065,7 +1065,7 @@
                 "cqrs",
                 "prooph"
             ],
-            "time": "2015-11-22 22:54:53"
+            "time": "2015-11-22T22:54:53+00:00"
         },
         {
             "name": "prooph/event-store-doctrine-adapter",
@@ -1131,7 +1131,7 @@
             ],
             "description": "Doctrine Adapter for ProophEventStore",
             "homepage": "http://getprooph.org/",
-            "time": "2016-06-28 19:49:20"
+            "time": "2016-06-28T19:49:20+00:00"
         },
         {
             "name": "prooph/psb-bernard-producer",
@@ -1195,7 +1195,7 @@
                 "messaging",
                 "prooph"
             ],
-            "time": "2016-08-22 20:00:38"
+            "time": "2016-08-22T20:00:38+00:00"
         },
         {
             "name": "prooph/service-bus",
@@ -1266,7 +1266,7 @@
                 "messaging",
                 "prooph"
             ],
-            "time": "2016-09-02 09:07:26"
+            "time": "2016-09-02T09:07:26+00:00"
         },
         {
             "name": "psr/http-message",
@@ -1316,7 +1316,7 @@
                 "request",
                 "response"
             ],
-            "time": "2016-08-06 14:39:51"
+            "time": "2016-08-06T14:39:51+00:00"
         },
         {
             "name": "ramsey/uuid",
@@ -1383,7 +1383,7 @@
                 "identifier",
                 "uuid"
             ],
-            "time": "2016-03-22 18:20:19"
+            "time": "2016-03-22T18:20:19+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -1443,7 +1443,7 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-19 10:45:57"
+            "time": "2016-07-19T10:45:57+00:00"
         },
         {
             "name": "symfony/serializer",
@@ -1516,7 +1516,7 @@
             ],
             "description": "Symfony Serializer Component",
             "homepage": "https://symfony.com",
-            "time": "2016-08-19 15:12:52"
+            "time": "2016-08-19T15:12:52+00:00"
         },
         {
             "name": "zendframework/zend-diactoros",
@@ -1566,7 +1566,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2016-09-07 17:57:29"
+            "time": "2016-09-07T17:57:29+00:00"
         },
         {
             "name": "zendframework/zend-escaper",
@@ -1610,7 +1610,7 @@
                 "escaper",
                 "zf2"
             ],
-            "time": "2016-06-30 19:48:38"
+            "time": "2016-06-30T19:48:38+00:00"
         },
         {
             "name": "zendframework/zend-expressive",
@@ -1680,7 +1680,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2016-01-28 15:49:52"
+            "time": "2016-01-28T15:49:52+00:00"
         },
         {
             "name": "zendframework/zend-expressive-fastroute",
@@ -1731,7 +1731,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2016-06-16 13:37:19"
+            "time": "2016-06-16T13:37:19+00:00"
         },
         {
             "name": "zendframework/zend-expressive-router",
@@ -1784,7 +1784,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2016-01-18 20:10:33"
+            "time": "2016-01-18T20:10:33+00:00"
         },
         {
             "name": "zendframework/zend-expressive-template",
@@ -1833,7 +1833,7 @@
                 "expressive",
                 "template"
             ],
-            "time": "2016-01-28 15:44:23"
+            "time": "2016-01-28T15:44:23+00:00"
         },
         {
             "name": "zendframework/zend-servicemanager",
@@ -1888,7 +1888,7 @@
                 "servicemanager",
                 "zf"
             ],
-            "time": "2016-07-15 14:59:51"
+            "time": "2016-07-15T14:59:51+00:00"
         },
         {
             "name": "zendframework/zend-stratigility",
@@ -1940,7 +1940,7 @@
                 "middleware",
                 "psr-7"
             ],
-            "time": "2016-03-24 22:10:30"
+            "time": "2016-03-24T22:10:30+00:00"
         }
     ],
     "packages-dev": [],
@@ -1952,7 +1952,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.0",
+        "php": "^7.1",
         "ext-pdo": "*",
         "ext-pdo_sqlite": "*"
     },

--- a/container.php
+++ b/container.php
@@ -196,7 +196,18 @@ return new ServiceManager([
             $buildings = $container->get(BuildingRepositoryInterface::class);
 
             return function (Command\RegisterNewBuilding $command) use ($buildings) {
-                $buildings->add(Building::new($command->name()));
+                $buildings->store(Building::new($command->name()));
+            };
+        },
+        Command\CheckInUser::class => function (ContainerInterface $container) : callable {
+            $buildings = $container->get(BuildingRepositoryInterface::class);
+
+            return function (Command\CheckInUser $command) use ($buildings) {
+                $building = $buildings->get($command->buildingId());
+
+                $building->checkInUser($command->username());
+
+                $buildings->store($building);
             };
         },
         BuildingRepositoryInterface::class => function (ContainerInterface $container) : BuildingRepositoryInterface {

--- a/public/index.php
+++ b/public/index.php
@@ -67,7 +67,11 @@ call_user_func(function () {
     });
 
     $app->post('/checkin/{buildingId}', function (Request $request, Response $response) use ($sm) : Response {
+        $buildingId = Uuid::fromString($request->getAttribute('buildingId'));
+        $commandBus = $sm->get(CommandBus::class);
+        $commandBus->dispatch(Command\CheckInUser::intoBuilding($buildingId, $request->getParsedBody()['username']));
 
+        return $response->withAddedHeader('Location', '/building/' . $buildingId->toString());
     });
 
     $app->post('/checkout/{buildingId}', function (Request $request, Response $response) use ($sm) : Response {

--- a/src/Domain/Aggregate/Building.php
+++ b/src/Domain/Aggregate/Building.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Building\Domain\Aggregate;
 
-use Building\Domain\DomainEvent\NewBuildingWasRegistered;
+use Building\Domain\DomainEvent;
 use Prooph\EventSourcing\AggregateRoot;
 use Rhumsaa\Uuid\Uuid;
 
@@ -24,7 +24,7 @@ final class Building extends AggregateRoot
     {
         $self = new self();
 
-        $self->recordThat(NewBuildingWasRegistered::occur(
+        $self->recordThat(DomainEvent\NewBuildingWasRegistered::occur(
             (string) Uuid::uuid4(),
             [
                 'name' => $name
@@ -34,20 +34,28 @@ final class Building extends AggregateRoot
         return $self;
     }
 
-    public function checkInUser(string $username)
+    public function checkInUser(string $username) : void
+    {
+        $this->recordThat(DomainEvent\UserCheckedIn::toBuilding(
+            $this->uuid,
+            $username
+        ));
+    }
+
+    public function checkOutUser(string $username) : void
     {
         // @TODO to be implemented
     }
 
-    public function checkOutUser(string $username)
-    {
-        // @TODO to be implemented
-    }
-
-    public function whenNewBuildingWasRegistered(NewBuildingWasRegistered $event)
+    protected function whenNewBuildingWasRegistered(DomainEvent\NewBuildingWasRegistered $event) : void
     {
         $this->uuid = Uuid::fromString($event->aggregateId());
         $this->name = $event->name();
+    }
+
+    protected function whenUserCheckedIn(DomainEvent\UserCheckedIn $event) : void
+    {
+        // empty on purpose
     }
 
     /**

--- a/src/Domain/Command/CheckInUser.php
+++ b/src/Domain/Command/CheckInUser.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Building\Domain\Command;
+
+use Prooph\Common\Messaging\Command;
+use Rhumsaa\Uuid\Uuid;
+
+final class CheckInUser extends Command
+{
+    /** @var string */
+    private $username;
+
+    /** @var Uuid */
+    private $buildingId;
+
+    private function __construct(Uuid $buildingId, string $username)
+    {
+        $this->init();
+
+        $this->buildingId = $buildingId;
+        $this->username   = $username;
+    }
+
+    public static function intoBuilding(Uuid $buildingId, string $username) : self
+    {
+        return new self($buildingId, $username);
+    }
+
+    public function buildingId() : Uuid
+    {
+        return $this->buildingId;
+    }
+
+    public function username() : string
+    {
+        return $this->username;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function payload() : array
+    {
+        return [
+            'username'   => $this->username,
+            'buildingId' => $this->buildingId->toString(),
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function setPayload(array $payload)
+    {
+        $this->username   = $payload['username'];
+        $this->buildingId = Uuid::fromString($payload['buildingId']);
+    }
+}

--- a/src/Domain/DomainEvent/UserCheckedIn.php
+++ b/src/Domain/DomainEvent/UserCheckedIn.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Building\Domain\DomainEvent;
+
+use Prooph\EventSourcing\AggregateChanged;
+use Rhumsaa\Uuid\Uuid;
+
+final class UserCheckedIn extends AggregateChanged
+{
+    public static function toBuilding(Uuid $buildingId, string $username) : self
+    {
+        return self::occur($buildingId->toString(), ['username' => $username]);
+    }
+    public function username() : string
+    {
+        return $this->payload['username'];
+    }
+
+    public function buildingId() : Uuid
+    {
+        return Uuid::fromString($this->aggregateId());
+    }
+}

--- a/src/Domain/Repository/BuildingRepositoryInterface.php
+++ b/src/Domain/Repository/BuildingRepositoryInterface.php
@@ -9,6 +9,6 @@ use Rhumsaa\Uuid\Uuid;
 
 interface BuildingRepositoryInterface
 {
-    public function add(Building $building);
+    public function store(Building $building);
     public function get(Uuid $id) : Building;
 }

--- a/src/Infrastructure/Repository/BuildingRepository.php
+++ b/src/Infrastructure/Repository/BuildingRepository.php
@@ -21,7 +21,7 @@ final class BuildingRepository implements BuildingRepositoryInterface
         $this->aggregateRepository = $aggregateRepository;
     }
 
-    public function add(Building $building)
+    public function store(Building $building)
     {
         $this->aggregateRepository->addAggregateRoot($building);
     }


### PR DESCRIPTION
This patch introduces:

 * the `CheckInUser` command, which requires both the `Uuid` of the `Building` where the check-in should be performed, and the username (in this workshop, we keep it as `string`) of the person performing the check-in
 * the `UserCheckedIn` event, recording the `username` that performed the check in. Note that the `aggregateId` is already a field of the base `AggregateChanged` class coming from Prooph.