### PR TITLE
Detect and react to check-in anomalies such as double check-in or invalid check-out operations, rather than crashing

### DIFF
--- a/src/Domain/Command/AlertSecurity.php
+++ b/src/Domain/Command/AlertSecurity.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Building\Domain\Command;
+
+use Prooph\Common\Messaging\Command;
+use Rhumsaa\Uuid\Uuid;
+
+final class AlertSecurity extends Command
+{
+    /** @var string */
+    private $username;
+
+    /** @var Uuid */
+    private $buildingId;
+
+    private function __construct(Uuid $buildingId, string $username)
+    {
+        $this->init();
+
+        $this->buildingId = $buildingId;
+        $this->username   = $username;
+    }
+
+    public static function ofBreachInBuilding(Uuid $buildingId, string $username) : self
+    {
+        return new self($buildingId, $username);
+    }
+
+    public function buildingId() : Uuid
+    {
+        return $this->buildingId;
+    }
+
+    public function username() : string
+    {
+        return $this->username;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function payload() : array
+    {
+        return [
+            'username'   => $this->username,
+            'buildingId' => $this->buildingId->toString(),
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function setPayload(array $payload)
+    {
+        $this->username   = $payload['username'];
+        $this->buildingId = Uuid::fromString($payload['buildingId']);
+    }
+}

--- a/src/Domain/DomainEvent/CheckInAnomalyDetected.php
+++ b/src/Domain/DomainEvent/CheckInAnomalyDetected.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Building\Domain\DomainEvent;
+
+use Prooph\EventSourcing\AggregateChanged;
+use Rhumsaa\Uuid\Uuid;
+
+final class CheckInAnomalyDetected extends AggregateChanged
+{
+    public static function inBuilding(Uuid $buildingId, string $username) : self
+    {
+        return self::occur($buildingId->toString(), ['username' => $username]);
+    }
+    public function username() : string
+    {
+        return $this->payload['username'];
+    }
+
+    public function buildingId() : Uuid
+    {
+        return Uuid::fromString($this->aggregateId());
+    }
+}


### PR DESCRIPTION
This patch introduces a synchronous "Process Manager", triggered when an event of `CheckInAnomalyDetected` event is propagated from the event stream to its listeners.

This process manager is supposed to request an external context (could be a separate system, aggregate or bounded context) about alerting security. To do so, a new command is raised, since we cannot guarantee that this interaction may fail nor succeed in deterministic time, since command execution is handled by the command bus, and the command bus has facilities for logging, retrying operations, and delegating long running operations to external dedicated systems.

Also, keep in mind that the `CheckInAnomalyDetected` event is raised *after* a `UserCheckedIn` or `UserCheckedOut`, because while the user should never have been allowed to check in twice, we don't have a sensible feedback mechanism to do so (by blocking the user physically), hence the related `UserCheckIn` or `UserCheckedOut` actually happened, even if anomalous.

