### PR TITLE
Rudimentary/manually built projection that writes checked in users to a web-accessible JSON file

### DIFF
--- a/bin/project-checked-in-users.php
+++ b/bin/project-checked-in-users.php
@@ -3,8 +3,14 @@
 
 declare(strict_types=1);
 
+namespace Projection;
+
+use Building\Domain\Aggregate\Building;
+use Building\Domain\DomainEvent\UserCheckedIn;
+use Building\Domain\DomainEvent\UserCheckedOut;
 use Interop\Container\ContainerInterface;
 use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Stream\StreamName;
 
 (function () {
     /** @var ContainerInterface $container */
@@ -12,16 +18,27 @@ use Prooph\EventStore\EventStore;
 
     $eventStore = $container->get(EventStore::class);
 
+    /** @var array<string, array<string, null>> $users */
     $users = [];
 
-    foreach ($eventStore->??? as $event) {
-        // ...
+    foreach ($eventStore->loadEventsByMetadataFrom(
+        new StreamName('event_stream'),
+        ['aggregate_type' => Building::class]
+    ) as $event) {
+        if ($event instanceof UserCheckedIn) {
+            $users[$event->buildingId()->toString()][$event->username()] = null;
+        }
 
-        // TODO TODO TODO
+        if ($event instanceof UserCheckedOut) {
+            unset($users[$event->buildingId()->toString()][$event->username()]);
+        }
+    }
+
+    array_walk($users, function (array $usernames, string $buildingId) : void {
         file_put_contents(
             __DIR__ . '/../public/building-' . $buildingId . '.json',
-            json_encode($users[$buildingId])
+            json_encode(array_keys($usernames))
         );
-    }
+    });
 })();
 

--- a/bin/project-checked-in-users.php
+++ b/bin/project-checked-in-users.php
@@ -1,0 +1,27 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use Interop\Container\ContainerInterface;
+use Prooph\EventStore\EventStore;
+
+(function () {
+    /** @var ContainerInterface $container */
+    $container = require __DIR__ . '/../container.php';
+
+    $eventStore = $container->get(EventStore::class);
+
+    $users = [];
+
+    foreach ($eventStore->??? as $event) {
+        // ...
+
+        // TODO TODO TODO
+        file_put_contents(
+            __DIR__ . '/../public/building-' . $buildingId . '.json',
+            json_encode($users[$buildingId])
+        );
+    }
+})();
+


### PR DESCRIPTION
In this change, we write the list of users that are currently in a building in `public/building-{$buildingId}.json`.

This is to emulate how a read-optimised projection would be built, if done from scratch.

In newer versions of Prooph, this is handled by a projection manager (provided by the library), which handles:

 * keeping the projection running
 * polling the event store for new events
 * keeping information about the last seen events, so that projection operations do not require restarting from the origin of  the event store's history

The duplication between this projection and the aggregate (which internally holds a similar data structure) is required in order to avoid coupling read model consumers with the write model (aggregate). As soon as we do that, we lose our ability to independently modify the structure of the read model and the write model.

Note also that this projection has to be manually triggered (it is an executable file), but it may as well be triggered via listeners, if necessary 